### PR TITLE
Move shebangs to #/usr/bin/env (ba)sh

### DIFF
--- a/INTERNET
+++ b/INTERNET
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Saumon i3blocks scripts
 # INTERNET (wired/wifi network info)

--- a/battery
+++ b/battery
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Saumon i3blocks scripts
 # battery (battery percentage and state)

--- a/brightness
+++ b/brightness
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Saumon i3blocks scripts
 # brightness (laptop brightness control)

--- a/date
+++ b/date
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Saumon i3blocks scripts
 # date (short date with quick copy actions)

--- a/desktopbrightness
+++ b/desktopbrightness
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Saumon i3blocks scripts
 # desktopbrightness (display and change external monitor brightness)

--- a/load
+++ b/load
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Saumon i3blocks scripts
 # load (1 minute load with colors)

--- a/music
+++ b/music
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Saumon i3blocks scripts
 # music (mpd/spotify track display and control)

--- a/ping
+++ b/ping
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Saumon i3blocks scripts
 # ping (current ping in ms to cloudfare)

--- a/ram
+++ b/ram
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Saumon i3blocks scripts
 # ram (current ram usage with swap warning)

--- a/separator
+++ b/separator
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Saumon i3blocks scripts
 # separator (small separator symbol)

--- a/temperature
+++ b/temperature
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Saumon i3blocks scripts
 # temperature (hardware temperature)

--- a/updates
+++ b/updates
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Saumon i3blocks scripts
 # updates (number of pending Arch Linux updates)

--- a/volume
+++ b/volume
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Saumon i3blocks scripts
 # volume (pulseaudio volume display and control)


### PR DESCRIPTION
Moves shebangs to /usr/bin/env

previous shells are still respected. sh stayed as sh, and bash stayed as bash
